### PR TITLE
Fixed an issue with the enumeration values in Pascal casing plus

### DIFF
--- a/src/main/java/sharpen/core/CSharpBuilder.java
+++ b/src/main/java/sharpen/core/CSharpBuilder.java
@@ -637,7 +637,8 @@ public class CSharpBuilder extends ASTVisitor {
         CSArrayInitializerExpression arrayInitializerExpression = new CSArrayInitializerExpression();
         for (Object o : enumNode.enumConstants()) {
             EnumConstantDeclaration constantDeclaration = (EnumConstantDeclaration) o;
-            arrayInitializerExpression.addExpression(new CSReferenceExpression(constantDeclaration.getName().getIdentifier()));
+            String constantIdentifier = fieldName(constantDeclaration);
+            arrayInitializerExpression.addExpression(new CSReferenceExpression(constantIdentifier));
         }
 
         CSArrayCreationExpression arrayCreationExpression = new CSArrayCreationExpression(enumType);

--- a/src/test/java/sharpen/ui/tests/FormattingTestCase.java
+++ b/src/test/java/sharpen/ui/tests/FormattingTestCase.java
@@ -13,6 +13,14 @@ public class FormattingTestCase extends AbstractConversionTestCase {
         return newConfigurationEgyptian();
     }
 
+    protected Configuration getPascalCasePlusConfiguration() {
+        return newPascalCasePlusConfiguration();
+    }
+
+    protected Configuration getPascalCaseIdentifiersConfiguration() {
+        return newPascalCaseIdentifiersConfiguration();
+    }
+
     @Override
     protected void runResourceTestCase(Configuration configuration, String resourceName) throws IOException, CoreException {
         super.runResourceTestCase(configuration, "formattings/" + resourceName);
@@ -21,6 +29,8 @@ public class FormattingTestCase extends AbstractConversionTestCase {
     @Test
     public void testIntentStyleEgyptianBrackets() throws Throwable {
         runResourceTestCase("IndentStyleEgyptianBrackets");
+        runResourceTestCase(getPascalCasePlusConfiguration(), "IndentStylePascalCasePlus");
+        runResourceTestCase(getPascalCaseIdentifiersConfiguration(), "IndentStylePascalCaseIdentifiers");
     }
 
 }

--- a/src/test/resources/formattings/IndentStylePascalCaseIdentifiers.cs
+++ b/src/test/resources/formattings/IndentStylePascalCaseIdentifiers.cs
@@ -1,0 +1,200 @@
+namespace formattings
+{
+	public class IndentStylePascalCaseIdentifiers
+	{
+		public int field1;
+
+		public long field2;
+
+		public string field3;
+
+		public virtual void Blocks()
+		{
+			while (field1 > 0)
+			{
+				field1--;
+				if (field1 % 10 == 0)
+				{
+					break;
+				}
+				if (field1 % 2 == 0)
+				{
+					field2 += 2;
+				}
+				else if (field1 % 3 == 0)
+				{
+					field2 += 3;
+				}
+				else if (field1 % 4 == 0)
+				{
+					if (field2 == 1)
+					{
+						field2 += 4;
+					}
+					else if (field2 == 2)
+					{
+						field2 += 5;
+					}
+					else
+					{
+						field2 += 6;
+					}
+				}
+				else
+				{
+					field2 += 7;
+				}
+			}
+			for (long i = 0; i < field2; i++)
+			{
+				if (i % 100 == 0)
+				{
+					field1++;
+				}
+				else
+				{
+					field2--;
+				}
+			}
+			try
+			{
+				do
+				{
+					field1--;
+				}
+				while (field1 > 10);
+			}
+			catch (System.Exception e)
+			{
+				System.Console.Out.WriteLine(e);
+			}
+			finally
+			{
+				System.Console.Out.WriteLine("done");
+			}
+			foreach (int v in System.Linq.Enumerable.ToList(new [] {1, 2, 3}))
+			{
+				System.Console.Out.WriteLine(v);
+				switch (v)
+				{
+					case 1:
+					{
+						System.Console.Out.WriteLine("a");
+						break;
+					}
+
+					case 2:
+					{
+						System.Console.Out.WriteLine("b");
+						break;
+					}
+
+					default:
+					{
+						System.Console.Out.WriteLine(string.Empty);
+						break;
+					}
+				}
+			}
+		}
+
+		public virtual void Method1(int v)
+		{
+			field1 = v;
+		}
+
+		public virtual string GetField3()
+		{
+			return field3;
+		}
+
+		public virtual void SetField3(string field3)
+		{
+			this.field3 = field3;
+		}
+
+		public virtual void MethodTryCatch1()
+		{
+			try
+			{
+				System.Console.Out.WriteLine(1);
+			}
+			catch (System.Exception)
+			{
+				System.Console.Out.WriteLine(2);
+			}
+		}
+
+		public virtual void MethodTryCatch2()
+		{
+			try
+			{
+				System.Console.Out.WriteLine(1);
+			}
+			catch (System.Exception)
+			{
+				System.Console.Out.WriteLine(2);
+			}
+			catch
+			{
+				System.Console.Out.WriteLine(3);
+			}
+			System.Console.Out.WriteLine(4);
+		}
+
+		private class InnerClass
+		{
+			public long field1;
+
+			public long field2;
+
+			public InnerClass()
+			{
+			}
+
+			public InnerClass(long field1, long field2)
+			{
+				this.field1 = field1;
+				this.field2 = field2;
+			}
+
+			public virtual void Method1(long v)
+			{
+				field1 = v;
+			}
+
+			public virtual void Method2(long v)
+			{
+				field2 = v;
+			}
+		}
+
+		[System.Serializable]
+		public sealed class MyEnum1 : nonamespace.EnumBase
+		{
+			public static readonly formattings.IndentStylePascalCaseIdentifiers.MyEnum1 VALUE1
+				 = new formattings.IndentStylePascalCaseIdentifiers.MyEnum1(0, "VALUE1");
+
+			public static readonly formattings.IndentStylePascalCaseIdentifiers.MyEnum1 VALUE2
+				 = new formattings.IndentStylePascalCaseIdentifiers.MyEnum1(1, "VALUE2");
+
+			public static readonly formattings.IndentStylePascalCaseIdentifiers.MyEnum1 VALUE3
+				 = new formattings.IndentStylePascalCaseIdentifiers.MyEnum1(2, "VALUE3");
+
+			private MyEnum1(int ordinal, string name)
+				: base(ordinal, name)
+			{
+			}
+
+			public static MyEnum1[] values()
+			{
+				return new MyEnum1[] { VALUE1, VALUE2, VALUE3 };
+			}
+
+			static MyEnum1()
+			{
+				RegisterValues<MyEnum1>(values());
+			}
+		}
+	}
+}

--- a/src/test/resources/formattings/IndentStylePascalCaseIdentifiers.java
+++ b/src/test/resources/formattings/IndentStylePascalCaseIdentifiers.java
@@ -1,0 +1,131 @@
+package formattings;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class IndentStylePascalCaseIdentifiers {
+
+    public int field1;
+    public long field2;
+    public String field3;
+
+
+    public void blocks() {
+        while (field1 > 0) {
+            field1--;
+            if (field1 % 10 == 0) {
+                break;
+            }
+            if (field1 % 2 == 0) {
+                field2 += 2;
+            } else if (field1 % 3 == 0) {
+                field2 += 3;
+            } else if (field1 % 4 == 0) {
+                if (field2 == 1) {
+                    field2 += 4;
+                } else if (field2 == 2) {
+                    field2 += 5;
+                } else {
+                    field2 += 6;
+                }
+            } else {
+                field2 += 7;
+            }
+        }
+        for (long i = 0; i < field2; i++) {
+            if (i % 100 == 0) {
+                field1++;
+            } else {
+                field2--;
+            }
+        }
+
+        try {
+            do {
+                field1--;
+            } while (field1 > 10);
+        } catch (Exception e) {
+            System.out.println(e);
+        } finally {
+            System.out.println("done");
+        }
+
+        for (Integer v : Arrays.asList(1, 2, 3)) {
+            System.out.println(v);
+
+            switch (v) {
+                case 1:
+                    System.out.println("a");
+                    break;
+                case 2: {
+                    System.out.println("b");
+                    break;
+                }
+                default: {
+                    System.out.println("");
+                }
+            }
+        }
+
+    }
+
+    public void method1(int v) {
+        field1 = v;
+    }
+
+    public String getField3() {
+        return field3;
+    }
+
+    public void setField3(String field3) {
+        this.field3 = field3;
+    }
+
+    public void methodTryCatch1() {
+        try {
+            System.out.println(1);
+        } catch (Exception e) {
+            System.out.println(2);
+        }
+    }
+
+    public void methodTryCatch2() {
+        try {
+            System.out.println(1);
+        } catch (Exception e) {
+            System.out.println(2);
+        } catch (Throwable e) {
+            System.out.println(3);
+        }
+        System.out.println(4);
+    }
+
+    private static class InnerClass {
+        public long field1;
+        public long field2;
+
+        public InnerClass() {
+        }
+
+        public InnerClass(long field1, long field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+
+        public void method1(long v) {
+            field1 = v;
+        }
+
+        public void method2(long v) {
+            field2 = v;
+        }
+
+    }
+
+    public enum MyEnum1 {
+        VALUE1,
+        VALUE2,
+        VALUE3,
+    }
+
+}

--- a/src/test/resources/formattings/IndentStylePascalCasePlus.cs
+++ b/src/test/resources/formattings/IndentStylePascalCasePlus.cs
@@ -1,0 +1,200 @@
+namespace Formattings
+{
+	public class IndentStylePascalCasePlus
+	{
+		public int field1;
+
+		public long field2;
+
+		public string field3;
+
+		public virtual void Blocks()
+		{
+			while (field1 > 0)
+			{
+				field1--;
+				if (field1 % 10 == 0)
+				{
+					break;
+				}
+				if (field1 % 2 == 0)
+				{
+					field2 += 2;
+				}
+				else if (field1 % 3 == 0)
+				{
+					field2 += 3;
+				}
+				else if (field1 % 4 == 0)
+				{
+					if (field2 == 1)
+					{
+						field2 += 4;
+					}
+					else if (field2 == 2)
+					{
+						field2 += 5;
+					}
+					else
+					{
+						field2 += 6;
+					}
+				}
+				else
+				{
+					field2 += 7;
+				}
+			}
+			for (long i = 0; i < field2; i++)
+			{
+				if (i % 100 == 0)
+				{
+					field1++;
+				}
+				else
+				{
+					field2--;
+				}
+			}
+			try
+			{
+				do
+				{
+					field1--;
+				}
+				while (field1 > 10);
+			}
+			catch (System.Exception e)
+			{
+				System.Console.Out.WriteLine(e);
+			}
+			finally
+			{
+				System.Console.Out.WriteLine("done");
+			}
+			foreach (int v in System.Linq.Enumerable.ToList(new [] {1, 2, 3}))
+			{
+				System.Console.Out.WriteLine(v);
+				switch (v)
+				{
+					case 1:
+					{
+						System.Console.Out.WriteLine("a");
+						break;
+					}
+
+					case 2:
+					{
+						System.Console.Out.WriteLine("b");
+						break;
+					}
+
+					default:
+					{
+						System.Console.Out.WriteLine(string.Empty);
+						break;
+					}
+				}
+			}
+		}
+
+		public virtual void Method1(int v)
+		{
+			field1 = v;
+		}
+
+		public virtual string GetField3()
+		{
+			return field3;
+		}
+
+		public virtual void SetField3(string field3)
+		{
+			this.field3 = field3;
+		}
+
+		public virtual void MethodTryCatch1()
+		{
+			try
+			{
+				System.Console.Out.WriteLine(1);
+			}
+			catch (System.Exception)
+			{
+				System.Console.Out.WriteLine(2);
+			}
+		}
+
+		public virtual void MethodTryCatch2()
+		{
+			try
+			{
+				System.Console.Out.WriteLine(1);
+			}
+			catch (System.Exception)
+			{
+				System.Console.Out.WriteLine(2);
+			}
+			catch
+			{
+				System.Console.Out.WriteLine(3);
+			}
+			System.Console.Out.WriteLine(4);
+		}
+
+		private class InnerClass
+		{
+			public long field1;
+
+			public long field2;
+
+			public InnerClass()
+			{
+			}
+
+			public InnerClass(long field1, long field2)
+			{
+				this.field1 = field1;
+				this.field2 = field2;
+			}
+
+			public virtual void Method1(long v)
+			{
+				field1 = v;
+			}
+
+			public virtual void Method2(long v)
+			{
+				field2 = v;
+			}
+		}
+
+		[System.Serializable]
+		public sealed class MyEnum1 : nonamespace.EnumBase
+		{
+			public static readonly Formattings.IndentStylePascalCasePlus.MyEnum1 Value1 = new 
+				Formattings.IndentStylePascalCasePlus.MyEnum1(0, "VALUE1");
+
+			public static readonly Formattings.IndentStylePascalCasePlus.MyEnum1 Value2 = new 
+				Formattings.IndentStylePascalCasePlus.MyEnum1(1, "VALUE2");
+
+			public static readonly Formattings.IndentStylePascalCasePlus.MyEnum1 Value3 = new 
+				Formattings.IndentStylePascalCasePlus.MyEnum1(2, "VALUE3");
+
+			private MyEnum1(int ordinal, string name)
+				: base(ordinal, name)
+			{
+			}
+
+			public static MyEnum1[] values()
+			{
+				return new MyEnum1[] { Value1, Value2, Value3 };
+			}
+
+			static MyEnum1()
+			{
+				RegisterValues<MyEnum1>(values());
+			}
+		}
+	}
+}

--- a/src/test/resources/formattings/IndentStylePascalCasePlus.java
+++ b/src/test/resources/formattings/IndentStylePascalCasePlus.java
@@ -1,0 +1,131 @@
+package formattings;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class IndentStylePascalCasePlus {
+
+    public int field1;
+    public long field2;
+    public String field3;
+
+
+    public void blocks() {
+        while (field1 > 0) {
+            field1--;
+            if (field1 % 10 == 0) {
+                break;
+            }
+            if (field1 % 2 == 0) {
+                field2 += 2;
+            } else if (field1 % 3 == 0) {
+                field2 += 3;
+            } else if (field1 % 4 == 0) {
+                if (field2 == 1) {
+                    field2 += 4;
+                } else if (field2 == 2) {
+                    field2 += 5;
+                } else {
+                    field2 += 6;
+                }
+            } else {
+                field2 += 7;
+            }
+        }
+        for (long i = 0; i < field2; i++) {
+            if (i % 100 == 0) {
+                field1++;
+            } else {
+                field2--;
+            }
+        }
+
+        try {
+            do {
+                field1--;
+            } while (field1 > 10);
+        } catch (Exception e) {
+            System.out.println(e);
+        } finally {
+            System.out.println("done");
+        }
+
+        for (Integer v : Arrays.asList(1, 2, 3)) {
+            System.out.println(v);
+
+            switch (v) {
+                case 1:
+                    System.out.println("a");
+                    break;
+                case 2: {
+                    System.out.println("b");
+                    break;
+                }
+                default: {
+                    System.out.println("");
+                }
+            }
+        }
+
+    }
+
+    public void method1(int v) {
+        field1 = v;
+    }
+
+    public String getField3() {
+        return field3;
+    }
+
+    public void setField3(String field3) {
+        this.field3 = field3;
+    }
+
+    public void methodTryCatch1() {
+        try {
+            System.out.println(1);
+        } catch (Exception e) {
+            System.out.println(2);
+        }
+    }
+
+    public void methodTryCatch2() {
+        try {
+            System.out.println(1);
+        } catch (Exception e) {
+            System.out.println(2);
+        } catch (Throwable e) {
+            System.out.println(3);
+        }
+        System.out.println(4);
+    }
+
+    private static class InnerClass {
+        public long field1;
+        public long field2;
+
+        public InnerClass() {
+        }
+
+        public InnerClass(long field1, long field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+
+        public void method1(long v) {
+            field1 = v;
+        }
+
+        public void method2(long v) {
+            field2 = v;
+        }
+
+    }
+
+    public enum MyEnum1 {
+        VALUE1,
+        VALUE2,
+        VALUE3,
+    }
+
+}


### PR DESCRIPTION
Hello,

This is a fix for an issue in the conversion of Enums using PascalCase+. It was not converting the names of the constants in the values method:

> 		public sealed class MyEnum1 : nonamespace.EnumBase
> 		{
> 			public static readonly Formattings.IndentStylePascalCasePlus.MyEnum1 Value1 = new 
> 				Formattings.IndentStylePascalCasePlus.MyEnum1(0, "VALUE1");
> 
> 			public static readonly Formattings.IndentStylePascalCasePlus.MyEnum1 Value2 = new 
> 				Formattings.IndentStylePascalCasePlus.MyEnum1(1, "VALUE2");
> 
> 			public static readonly Formattings.IndentStylePascalCasePlus.MyEnum1 Value3 = new 
> 				Formattings.IndentStylePascalCasePlus.MyEnum1(2, "VALUE3");
> 
> 			private MyEnum1(int ordinal, string name)
> 				: base(ordinal, name)
> 			{
> 			}
> 
> 			public static MyEnum1[] values()
> 			{
> 				return new MyEnum1[] { VALUE1, VALUE2, VALUE3 };
> 			}
> 
> 			static MyEnum1()
> 			{
> 				RegisterValues<MyEnum1>(values());
> 			}
> 		}

I also added formatting unit tests.