### PR TITLE
Fixed a bug with the enums in pascal casing

### DIFF
--- a/src/main/java/sharpen/core/CSharpBuilder.java
+++ b/src/main/java/sharpen/core/CSharpBuilder.java
@@ -630,7 +630,7 @@ public class CSharpBuilder extends ASTVisitor {
     private void implementEnumValuesMethod(EnumDeclaration enumNode, CSTypeDeclaration type) {
         CSTypeReference enumType = new CSTypeReference(enumNode.getName().getIdentifier());
 
-        CSMethod method = new CSMethod("values");
+        CSMethod method = new CSMethod(methodName("values"));
         method.visibility(CSVisibility.Public);
         method.modifier(CSMethodModifier.Static);
         method.returnType(new CSArrayTypeReference(enumType, 1));
@@ -653,7 +653,7 @@ public class CSharpBuilder extends ASTVisitor {
         CSConstructor staticConstructor = new CSConstructor(CSConstructorModifier.Static);
         CSMethodInvocationExpression methodInvocationExpression = new CSMethodInvocationExpression(new CSReferenceExpression("RegisterValues"));
         methodInvocationExpression.addTypeArgument(new CSTypeReference(enumNode.getName().getIdentifier()));
-        methodInvocationExpression.addArgument(new CSMethodInvocationExpression(new CSReferenceExpression("values")));
+        methodInvocationExpression.addArgument(new CSMethodInvocationExpression(new CSReferenceExpression(methodName("values"))));
         staticConstructor.body().addStatement(methodInvocationExpression);
         type.addMember(staticConstructor);
     }

--- a/src/test/resources/formattings/IndentStylePascalCaseIdentifiers.cs
+++ b/src/test/resources/formattings/IndentStylePascalCaseIdentifiers.cs
@@ -186,14 +186,14 @@ namespace formattings
 			{
 			}
 
-			public static MyEnum1[] values()
+			public static MyEnum1[] Values()
 			{
 				return new MyEnum1[] { VALUE1, VALUE2, VALUE3 };
 			}
 
 			static MyEnum1()
 			{
-				RegisterValues<MyEnum1>(values());
+				RegisterValues<MyEnum1>(Values());
 			}
 		}
 	}

--- a/src/test/resources/formattings/IndentStylePascalCasePlus.cs
+++ b/src/test/resources/formattings/IndentStylePascalCasePlus.cs
@@ -166,6 +166,7 @@ namespace Formattings
 			public virtual void Method2(long v)
 			{
 				field2 = v;
+				Formattings.IndentStylePascalCasePlus.MyEnum1.Values();
 			}
 		}
 
@@ -186,14 +187,14 @@ namespace Formattings
 			{
 			}
 
-			public static MyEnum1[] values()
+			public static MyEnum1[] Values()
 			{
 				return new MyEnum1[] { Value1, Value2, Value3 };
 			}
 
 			static MyEnum1()
 			{
-				RegisterValues<MyEnum1>(values());
+				RegisterValues<MyEnum1>(Values());
 			}
 		}
 	}

--- a/src/test/resources/formattings/IndentStylePascalCasePlus.java
+++ b/src/test/resources/formattings/IndentStylePascalCasePlus.java
@@ -118,6 +118,7 @@ public class IndentStylePascalCasePlus {
 
         public void method2(long v) {
             field2 = v;
+            MyEnum1.values();
         }
 
     }


### PR DESCRIPTION
Hello,
In the enums, the "values()" was not properly formatted in pascal casing.
That's all!